### PR TITLE
Minor change in docker-compose to BasicAuth

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     container_name: silverbullet
     restart: unless-stopped
     ## To enable additional options, such as BasicAuth, uncomment the following line:
-    # command: --user='user:pw'
+    # command: ["--user=user:pw"]
     volumes:
       - space:/space
     ports:


### PR DESCRIPTION
I propose changing to a list element the "command" line in docker-compose, to align to dockerfile style and allow users to just uncomment and insert desired user:pwd styles.